### PR TITLE
AWS config shouldn't be required, or at least validated.

### DIFF
--- a/lib/Tests/index-test.js
+++ b/lib/Tests/index-test.js
@@ -16,23 +16,6 @@ var testGroup = {
         test.notEqual(client, null);
         test.done();
     },
-    "createClient fails if environment variables aren't set up correctly": function (test) {
-        process.env.AWS_ACCESS_KEY_ID = "xxx";
-        process.env.AWS_SECRET_ACCESS_KEY = "xxx";
-        process.env.AWS_REGION = "";
-        test.throws(function () {
-            var client = lib.createClient(null);
-        }, errors.InvalidArgumentError);
-        process.env.AWS_SECRET_ACCESS_KEY = "";
-        test.throws(function () {
-            var client = lib.createClient(null);
-        }, errors.InvalidArgumentError);
-        process.env.AWS_ACCESS_KEY_ID = "";
-        test.throws(function () {
-            var client = lib.createClient(null);
-        }, errors.InvalidArgumentError);
-        test.done();
-    },
     "can create a client that provides AWS config as a param": function (test) {
         var config = {
             accessKeyId: "abc",

--- a/lib/Tests/index-test.ts
+++ b/lib/Tests/index-test.ts
@@ -288,4 +288,4 @@ var testGroup = {
 
 };
 
-exports.indexTests = testGroup; 
+exports.indexTests = testGroup;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,24 +1,15 @@
 var AWS = require("aws-sdk");
 var easySqs = require("./EasySqs");
 var errors = require("./CustomErrors");
-function createClient(awsConfig) {
-    validateConfig(awsConfig);
+function createClient(sqsConfig, awsConfig) {
+
     if (awsConfig != null) {
         AWS.config.update(awsConfig);
     }
-    return new SqsClient(new AWS.SQS());
+    return new SqsClient(new AWS.SQS(sqsConfig));
 }
 exports.createClient = createClient;
-function validateConfig(awsConfig) {
-    if (awsConfig && awsConfig.accessKeyId && awsConfig.secretAccessKey && awsConfig.region)
-        return;
-    if (!process.env.AWS_ACCESS_KEY_ID)
-        throw new errors.InvalidArgumentError("accessKeyId not found in config or process.env.AWS_ACCESS_KEY_ID");
-    if (!process.env.AWS_SECRET_ACCESS_KEY)
-        throw new errors.InvalidArgumentError("secretAccessKey not found in config or process.env.AWS_SECRET_ACCESS_KEY");
-    if (!process.env.AWS_REGION)
-        throw new errors.InvalidArgumentError("region not found in config or process.env.AWS_REGION");
-}
+
 //deprecated
 function CreateClient(accessKey, secretKey, region) {
     console.warn("CreateClient is now deprecated. Please use createClient instead");

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var AWS = require("aws-sdk");
 var easySqs = require("./EasySqs");
 var errors = require("./CustomErrors");
-function createClient(sqsConfig, awsConfig) {
+function createClient(awsConfig, sqsConfig) {
 
     if (awsConfig != null) {
         AWS.config.update(awsConfig);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import easySqs = require("./EasySqs");
 import errors = require("./CustomErrors");
 import interfaces = require("./Interfaces");
 
-export function createClient(sqsConfig?: any, awsConfig?: any) {
+export function createClient(awsConfig?: any, sqsConfig?: any) {
 
   if (awsConfig != null) {
     AWS.config.update(awsConfig);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,26 +3,14 @@ import easySqs = require("./EasySqs");
 import errors = require("./CustomErrors");
 import interfaces = require("./Interfaces");
 
-export function createClient(awsConfig?: any) {
-
-  validateConfig(awsConfig);
+export function createClient(sqsConfig?: any, awsConfig?: any) {
 
   if (awsConfig != null) {
     AWS.config.update(awsConfig);
   }
-
-  return new SqsClient(new AWS.SQS());
+  return new SqsClient(new AWS.SQS(sqsConfig));
 }
 
-function validateConfig(awsConfig: any) {
-
-  if (awsConfig && awsConfig.accessKeyId && awsConfig.secretAccessKey && awsConfig.region) return;
-
-  if (!process.env.AWS_ACCESS_KEY_ID) throw new errors.InvalidArgumentError("accessKeyId not found in config or process.env.AWS_ACCESS_KEY_ID");
-  if (!process.env.AWS_SECRET_ACCESS_KEY) throw new errors.InvalidArgumentError("secretAccessKey not found in config or process.env.AWS_SECRET_ACCESS_KEY");
-  if (!process.env.AWS_REGION) throw new errors.InvalidArgumentError("region not found in config or process.env.AWS_REGION");
-
-}
 
 //deprecated
 export function CreateClient(accessKey: string, secretKey: string, region: string): ISqsClient {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "nodeunit": "^0.9.1"
   },
   "dependencies": {
-    "aws-sdk": "^2.1.30"
+    "aws-sdk": "^2.1.39"
   },
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
The access keys are already validated by the AWS sdk, they should be passed in if provided, but not validated by the library.  

This decouples the lib from how AWS expects its parameters, giving the flexibility to the end user to set up the project as needed.
