### PR TITLE
Update version of aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "nodeunit": "^0.10.2"
   },
   "dependencies": {
-    "aws-sdk": "^2.1.39"
+    "aws-sdk": "^2.6.9"
   },
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
The required version of aws-sdk in the package.json is quite old and could be updated. We use IAM Roles for ECS task definitions which the required aws-sdk version in this module doesn't support yet.
